### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/405273/a464a51f-a9d3-415a-983c-ecc9f9e1e117/e58d8192-5262-4682-856c-da357d004679/_apis/work/boardbadge/8203b7d2-166a-4745-ab05-5fc958846334)](https://dev.azure.com/405273/a464a51f-a9d3-415a-983c-ecc9f9e1e117/_boards/board/t/e58d8192-5262-4682-856c-da357d004679/Microsoft.RequirementCategory)
 ![ipost-logo](./assets/logo-name.png)
 <h3 align="middle">
   <a href="https://github.com/FIPost/docs">Documentation</a>


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#350](https://dev.azure.com/405273/a464a51f-a9d3-415a-983c-ecc9f9e1e117/_workitems/edit/350). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.